### PR TITLE
Explicitly set hash function in slave GW configuration

### DIFF
--- a/worker/tyk_worker.conf
+++ b/worker/tyk_worker.conf
@@ -46,6 +46,7 @@
     "allow_explicit_policy_id": true
   },
   "hash_keys": true,
+  "hash_key_function": "murmur64",
   "suppress_redis_signal_reload": false,
   "use_sentry": false,
   "sentry_code": "",


### PR DESCRIPTION
Have found the following:
- When using standard authentication, everything works fine even if `hash_key_function` is not set on the slave GW config. file.
- When using basic auth, slave key retrieval is broken (basically master GW sets a key like `apikey-cb77bcf99289c78e` but slave tries to get `apikey-e2a8e152`).
- To summarize I think we should be strict and set the appropriate `hash_key_function` in the slave GW config. file.